### PR TITLE
Remove italics in toc

### DIFF
--- a/src/epub/toc.xhtml
+++ b/src/epub/toc.xhtml
@@ -56,7 +56,7 @@
 					<a href="text/chapter-14.xhtml"><span epub:type="z3998:roman">XIV</span>: Norris Takes a Short Holiday</a>
 				</li>
 				<li>
-					<a href="text/chapter-15.xhtml"><span epub:type="z3998:roman">XV</span>: <em>Versus</em> Charchester (At Charchester)</a>
+					<a href="text/chapter-15.xhtml"><span epub:type="z3998:roman">XV</span>: Versus Charchester (At Charchester)</a>
 				</li>
 				<li>
 					<a href="text/chapter-16.xhtml"><span epub:type="z3998:roman">XVI</span>: A Disputed Authorship</a>


### PR DESCRIPTION
Italics were removed from chapter title (chapter-15.xhtml) in commit 7103af004077c88cbbedc88fad3c61a5e40607ec, but was still italicized in table of contents